### PR TITLE
Remove command to install libhiredis deb file

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,12 +32,11 @@ steps:
 
 - script: |
     set -xe
-    sudo apt-get -y purge libhiredis-dev libnl-3-dev libnl-route-3-dev
+    sudo apt-get -y purge libnl-3-dev libnl-route-3-dev
     sudo dpkg -i libnl-3-200_*.deb
     sudo dpkg -i libnl-genl-3-200_*.deb
     sudo dpkg -i libnl-route-3-200_*.deb
     sudo dpkg -i libnl-nf-3-200_*.deb
-    sudo dpkg -i libhiredis0.14_*.deb
     sudo dpkg -i libyang_1.*.deb
     sudo dpkg -i libswsscommon_1.0.0_amd64.deb
     sudo dpkg -i python3-swsscommon_1.0.0_amd64.deb


### PR DESCRIPTION
libhiredis is now used as-is from the slave container, since we're not making any changes to this package. See also
sonic-net/sonic-buildimage#15633.