### PR TITLE
Handle exception to avoid lldp_syncd crash

### DIFF
--- a/src/lldp_syncd/daemon.py
+++ b/src/lldp_syncd/daemon.py
@@ -194,6 +194,8 @@ class LldpSyncDaemon(SonicSyncDaemon):
         logger.debug("Invoking lldpcli with: {}".format(cmd_local))
 
         lldp_json = self._scrap_output(cmd)
+        if lldp_json is None:
+            return None
         lldp_json['lldp_loc_chassis'] = self._scrap_output(cmd_local)
 
         return lldp_json

--- a/tests/test_lldpSyncDaemon.py
+++ b/tests/test_lldpSyncDaemon.py
@@ -179,3 +179,42 @@ class TestLldpSyncDaemon(TestCase):
                     jo[k] = db.get_all(db.APPL_DB, k)
         if 'LLDP_ENTRY_TABLE:Ethernet104' in jo:
             self.fail("After removing Ethernet104, it is still found in APPL_DB!")
+
+    @mock.patch('subprocess.check_output')
+    def test_invalid_chassis_name(self, mock_check_output):
+        # mock the invalid chassis name
+        mock_check_output.return_value = '''
+        {
+            "local-chassis": {
+                "chassis": {
+                    "chassis_name\1": {
+                        "id": {
+                        "type": "mac",
+                        "value": "aa:bb:cc:dd:ee:ff"
+                        },
+                        "descr": "SONiC Software Version: SONiC.20230531.22",
+                        "capability": [
+                            {
+                                "type": "Bridge",
+                                "enabled": true
+                            },
+                            {
+                                "type": "Router",
+                                "enabled": true
+                            },
+                            {
+                                "type": "Wlan",
+                                "enabled": false
+                            },
+                            {
+                                "type": "Station",
+                                "enabled": false
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+        '''
+        result = self.daemon.source_update()
+        self.assertIsNone(result)


### PR DESCRIPTION
# Issue description
When there is invalid string in chassis name or other fields, json.load could throw exception and return None in function _scrap_output, it could cause TypeError: 'NoneType' object does not support item assignment when running the following code:

`lldp_json['lldp_loc_chassis'] = self._scrap_output(cmd_local`


Traceback looks like below and cause lldp_syncd crash:
```
May  6 21:31:23.136172 docker ps ERR lldp#lldp-syncd [lldp_syncd] ERROR: Failed to parse lldpctl output#012Traceback (most recent call last):#012  File "/usr/local/lib/python3.9/dist-packages/lldp_syncd/daemon.py", line 180, in _scrap_output#012    lldpctl_json = json.loads(lldpctl_output)#012  File "/usr/lib/python3.9/json/__init__.py", line 346, in loads#012    return _default_decoder.decode(s)#012  File "/usr/lib/python3.9/json/decoder.py", line 337, in decode#012    obj, end = self.raw_decode(s, idx=_w(s, 0).end())#012  File "/usr/lib/python3.9/json/decoder.py", line 353, in raw_decode#012    obj, end = self.scan_once(s, idx)#012json.decoder.JSONDecodeError: Invalid \escape: line 130 column 14 (char 3552)
May  6 21:31:23.147700 LON21-0101-0105-12T1 INFO lldp#supervisord: lldp-syncd Exception in thread LldpSyncDaemon:
May  6 21:31:23.147700 LON21-0101-0105-12T1 INFO lldp#supervisord: lldp-syncd Traceback (most recent call last):
May  6 21:31:23.147700 LON21-0101-0105-12T1 INFO lldp#supervisord: lldp-syncd   File "/usr/lib/python3.9/threading.py", line 954, in _bootstrap_inner
May  6 21:31:23.148327 LON21-0101-0105-12T1 INFO lldp#supervisord: lldp-syncd     self.run()
May  6 21:31:23.148327 LON21-0101-0105-12T1 INFO lldp#supervisord: lldp-syncd   File "/usr/local/lib/python3.9/dist-packages/sonic_syncd/interface.py", line 43, in run
May  6 21:31:23.148725 LON21-0101-0105-12T1 INFO lldp#supervisord: lldp-syncd     update_obj = self.source_update()
May  6 21:31:23.148763 LON21-0101-0105-12T1 INFO lldp#supervisord: lldp-syncd   File "/usr/local/lib/python3.9/dist-packages/lldp_syncd/daemon.py", line 197, in source_update
May  6 21:31:23.148782 LON21-0101-0105-12T1 INFO lldp#supervisord: lldp-syncd     lldp_json['lldp_loc_chassis'] = self._scrap_output(cmd_local)
May  6 21:31:23.148800 LON21-0101-0105-12T1 INFO lldp#supervisord: lldp-syncd TypeError: 'NoneType' object does not support item assignment
May  6 21:31:23.183356 LON21-0101-0105-12T1 INFO lldp#supervisord 2024-05-06 21:31:23,182 INFO exited: lldp-syncd (exit status 0; expected)
```

#  How to fix
Handle None returned value in `source_update` and return None if can't parse the lldpctl json output.
This can avoid lldp_syncd crash.

The expected syslog for invalid output in lldpctl command:
`May 21 07:11:35.135275 hostname WARNING lldp#lldp-syncd [sonic_syncd] WARNING: No source information returned during last update. Skipping sync.`


# workitem
28004915