### PR TITLE
[lldp]Fix the issue of only one field lldp_rem_time_mark in APPL_DB

### DIFF
--- a/tests/test_lldpSyncDaemon.py
+++ b/tests/test_lldpSyncDaemon.py
@@ -220,7 +220,7 @@ class TestLldpSyncDaemon(TestCase):
         self.assertIsNone(result)
 
 
-    def test_new_interface(self):
+    def test_changed_interface(self):
         parsed_update = self.daemon.parse_update(self._json)
         self.daemon.sync(parsed_update)
         db = create_dbconnector()
@@ -230,62 +230,15 @@ class TestLldpSyncDaemon(TestCase):
         for k in keys:
             if k != 'LLDP_LOC_CHASSIS':
                 if TABLE_PREFIX + 'eth0' == k or TABLE_PREFIX + 'Ethernet0' == k:
-                    dump[k] = db.get(db.APPL_DB, k, 'lldp_rem_port_desc')
-                elif TABLE_PREFIX + 'Ethernet100' == k:
-                    dump[k] = db.get(db.APPL_DB, k, 'lldp_rem_port_desc')
+                    dump[k] = db.get(db.APPL_DB, k, 'lldp_rem_time_mark')
 
         time.sleep(1)
         # simulate lldp_rem_time_mark was changed or port description was changed or interface was removed
-        new_json = self._json.copy()
-        new_interface = {
-            "Ethernet1": {
-                "rid": "1",
-                "port": {
-                "id": {
-                    "type": "ifname",
-                    "value": "Ethernet1"
-                },
-                "descr": "Ethernet1, this is a port description",
-                "mfs": "9236"
-                },
-                "via": "LLDP",
-                "chassis": {
-                "switch13": {
-                    "mgmt-ip": "10.3.147.196",
-                    "id": {
-                    "type": "mac",
-                    "value": "00:11:22:33:44:55"
-                    },
-                    "ttl": "120",
-                    "descr": "Ethernet1, I'm a little teapot.",
-                    "capability": [
-                    {
-                        "type": "Bridge",
-                        "enabled": True
-                    },
-                    {
-                        "type": "Router",
-                        "enabled": True
-                    }
-                    ]
-                }
-                },
-                "age": "0 day, 05:09:05",
-                "vlan": [
-                {
-                    "vlan-id": "101",
-                    "pvid": True
-                },
-                {
-                    "vlan-id": "201",
-                    "value": "vlan201"
-                }
-                ]
-            }
-        }
-        new_json['lldp']['interface'].append(new_interface)
+        changed_json = self._json.copy()
+        changed_json['lldp']['interface'][0]['eth0']['age'] = '0 day, 05:09:12'
+        changed_json['lldp']['interface'][1]['Ethernet0']['age'] = '0 day, 05:09:15'
 
-        parsed_update = self.daemon.parse_update(new_json)
+        parsed_update = self.daemon.parse_update(changed_json)
         self.daemon.sync(parsed_update)
         keys = db.keys(db.APPL_DB)
 
@@ -293,21 +246,7 @@ class TestLldpSyncDaemon(TestCase):
         for k in keys:
             if k != 'LLDP_LOC_CHASSIS':
                 if TABLE_PREFIX + 'eth0' == k or TABLE_PREFIX + 'Ethernet0' == k:
-                    jo[k] = db.get(db.APPL_DB, k, 'lldp_rem_port_desc')
-                    self.assertEqual(jo[k], dump[k])
-                elif TABLE_PREFIX + 'Ethernet1' == k:
-                    jo[k] = db.get(db.APPL_DB, k, 'lldp_rem_port_id')
-                    self.assertEqual(jo[k], "Ethernet1")
-                    jo[k] = db.get(db.APPL_DB, k, 'lldp_rem_port_desc')
-                    self.assertEqual(jo[k], "Ethernet1, this is a port description")
+                    jo[k] = db.get(db.APPL_DB, k, 'lldp_rem_time_mark')
+                    self.assertEqual(int(jo[k]), int(dump[k])+10)
                 else:
                     jo[k] = db.get_all(db.APPL_DB, k)
-
-        #Find and remove the Ethernet1 dictionary, restore test data
-        for interface_dict in new_json["lldp"]["interface"]:
-            if "Ethernet1" in interface_dict:
-                new_json["lldp"]["interface"].remove(interface_dict)
-                break  # Exit loop after removing
-        parsed_update = self.daemon.parse_update(new_json)
-        self.daemon.sync(parsed_update)
-        keys = db.keys(db.APPL_DB)


### PR DESCRIPTION
- Description:

It still has the following syslog:
`2024 Dec  2 18:22:18.291732 bjw2-can-7260-3 WARNING snmp#snmp-subagent [sonic_ax_impl] WARNING: Exception when updating lldpRemTable: 'lldp_rem_index'`

It always happened for `eth0`, the `LLDP_ENTRY_TABLE` in  `APPL_DB` for `eth0` is like this:
`{'lldp_rem_time_mark': '3886'}`

**reproduce steps:**

```
docker exec syncd supervisorctl stop syncd
docker exec swss supervisorctl stop orchagent

docker exec syncd supervisorctl start syncd
docker exec swss supervisorctl start orchagent
```

**Root cause:**

restart syncd and orchagent, other interfaces are down, but eth0 is still up. So, it is always in changed list and still it thinks the only changed field is lldp_rem_time_mark. But APPL_DB was flushed, the `LLDP_ENTRY_TABLE:eth0` is empty. During every lldp-syncd daemon run function, it only updates the `lldp_rem_time_mark` field for eth0. And it doesn't have other chance to write other fields into the table, except shutdown/ no shutdown eth0 or restart lldp.

- How to fix:

repopulate APPL_DB lldp table for changed interface if detects any new or deleted interfaces.
Even syncd or orchagent restarts, other interfaces will down and then up, eth0 still has change to rewrite all fields

- Test:

```
admin@str2-7260cx3-acs-12:/var/log$ sonic-db-cli APPL_DB FLUSHDB
True
admin@str2-7260cx3-acs-12:/var/log$ sonic-db-cli APPL_DB hgetall LLDP_ENTRY_TABLE:eth0
{'lldp_rem_time_mark': '504'}
admin@str2-7260cx3-acs-12:/var/log$ sonic-db-cli APPL_DB hgetall LLDP_ENTRY_TABLE:eth0
{'lldp_rem_time_mark': '504'}
admin@str2-7260cx3-acs-12:/var/log$ sonic-db-cli APPL_DB hgetall LLDP_ENTRY_TABLE:Ethernet68
{'lldp_rem_time_mark': '519'}
admin@str2-7260cx3-acs-12:/var/log$ sudo config interface shutdown Ethernet68
admin@str2-7260cx3-acs-12:/var/log$ sonic-db-cli APPL_DB hgetall LLDP_ENTRY_TABLE:Ethernet68
{}
admin@str2-7260cx3-acs-12:/var/log$ sonic-db-cli APPL_DB hgetall LLDP_ENTRY_TABLE:eth0
{'lldp_rem_sys_cap_enabled': '28 00', 'lldp_rem_man_addr': '', 'lldp_rem_sys_desc': 'Cisco Nexus Operating System (NX-OS) Software 6.0(2)U6(7)
TAC support: http://www.cisco.com/tac
Copyright (c) 2002-2016, Cisco Systems, Inc. All rights reserved.', 'lldp_rem_index': '1', 'lldp_rem_port_desc': 'Ethernet1/5', 'lldp_rem_chassis_id_subtype': '4', 'lldp_rem_port_id': 'Ethernet1/5', 'lldp_rem_port_id_subtype': '5', 'lldp_rem_time_mark': '695', 'lldp_rem_sys_name': 'STR-MGSW-254-C14.ntwk.msn.net', 'lldp_rem_sys_cap_supported': '28 00', 'lldp_rem_chassis_id': 'ac:4a:67:d4:fe:ac'}
```

- Microsoft work item

30233240
